### PR TITLE
chore: Phase 1 repo professionalization (draft)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+charset = utf-8
+
+[*.py]
+indent_style = space
+indent_size = 4
+
+[*.{yml,yaml,json,toml,md}]
+indent_style = space
+indent_size = 2
+
+[Makefile]
+indent_style = tab

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @kakkato @rgrieselhuber

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,82 @@
+name: Bug report
+description: Report a bug in demandsphere-mcp
+labels: ["bug", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug report. Please redact API keys
+        from any logs you paste below.
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: Describe the unexpected behavior.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect?
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Reproduction steps
+      description: Minimal steps to reproduce
+    validations:
+      required: true
+  - type: input
+    id: python-version
+    attributes:
+      label: Python version
+      placeholder: "e.g. 3.12.2"
+    validations:
+      required: true
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating system
+      options:
+        - macOS
+        - Linux
+        - Windows
+        - Other
+    validations:
+      required: true
+  - type: dropdown
+    id: client
+    attributes:
+      label: MCP client
+      options:
+        - Claude Desktop
+        - Claude Code
+        - Cursor
+        - ChatGPT Deep Research
+        - Other
+    validations:
+      required: true
+  - type: input
+    id: server-version
+    attributes:
+      label: MCP server version
+      placeholder: "e.g. 0.2.0"
+    validations:
+      required: true
+  - type: dropdown
+    id: transport
+    attributes:
+      label: Transport
+      options:
+        - stdio
+        - streamable-http
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs
+      description: |
+        Relevant log output. Redact API keys before pasting.
+      render: text

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: mailto:security@demandsphere.com
+    about: Report security issues privately. Do NOT open a public issue.
+  - name: DemandSphere API / account questions
+    url: https://help.demandsphere.com
+    about: For API or account questions, see the Help Center (login required).

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,20 @@
+name: Feature request
+description: Suggest a new tool, workflow, or improvement
+labels: ["enhancement", "triage"]
+body:
+  - type: textarea
+    id: use-case
+    attributes:
+      label: Use case
+      description: What problem does this solve? Who benefits?
+    validations:
+      required: true
+  - type: textarea
+    id: proposed
+    attributes:
+      label: Proposed API or behavior
+      description: How would it work?
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,18 @@
+## Summary
+
+<!-- 1-3 sentences on what this PR does and why -->
+
+## Checklist
+
+- [ ] Tests added or updated
+- [ ] `uv run ruff check src/ tests/` passes
+- [ ] `uv run ruff format --check src/ tests/` passes
+- [ ] `uv run pytest` passes locally
+- [ ] Type hints added on new public API
+- [ ] `CHANGELOG.md` updated (only if user-facing change)
+- [ ] No secrets, API keys, or `.env` / `config.json` committed
+- [ ] No files under `.ai/` included
+
+## Notes for reviewers
+
+<!-- anything reviewers should pay attention to -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,7 +9,7 @@
 - [ ] `uv run ruff format --check src/ tests/` passes
 - [ ] `uv run pytest` passes locally
 - [ ] Type hints added on new public API
-- [ ] `CHANGELOG.md` updated (only if user-facing change)
+- [ ] `CHANGELOG.md` **not** modified (release PRs only — see [CLAUDE.md](../CLAUDE.md) forbidden patterns)
 - [ ] No secrets, API keys, or `.env` / `config.json` committed
 - [ ] No files under `.ai/` included
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      patch-and-minor:
+        update-types: ["patch", "minor"]
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,40 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+      - uses: astral-sh/setup-uv@0c5e2b8115b80b4c7c5ddf6ffdd634974642d182  # v5.4.1
+        with:
+          python-version: "3.12"
+      - run: uv sync --extra dev
+      - run: uv run ruff check src/ tests/
+      - run: uv run ruff format --check src/ tests/
+
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        python: ["3.11", "3.12", "3.13"]
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+      - uses: astral-sh/setup-uv@0c5e2b8115b80b4c7c5ddf6ffdd634974642d182  # v5.4.1
+        with:
+          python-version: ${{ matrix.python }}
+      - run: uv sync --extra dev
+      - run: uv run pytest -v

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -13,6 +13,11 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           fetch-depth: 0
-      - uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7  # v2.3.9
-        with:
-          config-path: .gitleaks.toml
+      - name: Install gitleaks
+        run: |
+          GITLEAKS_VERSION=8.30.1
+          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
+            | tar -xz gitleaks
+          sudo mv gitleaks /usr/local/bin/
+      - name: Run gitleaks
+        run: gitleaks detect --config .gitleaks.toml --source . --log-opts="origin/main..HEAD" --verbose

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -15,9 +15,14 @@ jobs:
           fetch-depth: 0
       - name: Install gitleaks
         run: |
+          set -euo pipefail
           GITLEAKS_VERSION=8.30.1
-          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
-            | tar -xz gitleaks
+          TARBALL="gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
+          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/${TARBALL}" -o "${TARBALL}"
+          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_checksums.txt" -o checksums.txt
+          grep " ${TARBALL}$" checksums.txt | sha256sum -c -
+          tar -xzf "${TARBALL}" gitleaks
           sudo mv gitleaks /usr/local/bin/
+          gitleaks version
       - name: Run gitleaks
         run: gitleaks detect --config .gitleaks.toml --source . --log-opts="origin/main..HEAD" --verbose

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,0 +1,18 @@
+name: secret-scan
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  gitleaks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        with:
+          fetch-depth: 0
+      - uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7  # v2.3.9
+        with:
+          config-path: .gitleaks.toml

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+# Python
 __pycache__/
 *.py[cod]
 *.egg-info/
@@ -6,9 +7,46 @@ build/
 .eggs/
 .venv/
 venv/
-.env
 *.lock
+
+# Caches
 .ruff_cache/
 .pytest_cache/
 .mypy_cache/
+
+# OS
 .DS_Store
+
+# Secrets & config
+.env
+.env.*
+!.env.example
+config.json
+*.pem
+*.key
+
+# IDE / editor
+.vscode/
+.idea/
+*.swp
+*~
+
+# Coverage / test artifacts
+htmlcov/
+.coverage
+.coverage.*
+coverage.xml
+.tox/
+.nox/
+
+# Agent tooling — personal only
+CLAUDE.local.md
+AGENTS.local.md
+.claude/settings.local.json
+.claude/cache/
+.claude/logs/
+.claude/todos/
+.cursor/rules.local.mdc
+
+# Working artifacts (AI-agent specs, plans, notes)
+.ai/

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -19,4 +19,5 @@ paths = [
 regexes = [
     '''YOUR_DEMANDSPHERE_API_KEY''',
     '''your-api-key''',
+    '''YOUR_API_KEY_HERE''',
 ]

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -14,6 +14,7 @@ paths = [
     '''examples/.*''',
     '''tests/.*''',
     '''\.ai/.*''',
+    '''\.secrets\.baseline''',
 ]
 regexes = [
     '''YOUR_DEMANDSPHERE_API_KEY''',

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,21 @@
+title = "demandsphere-mcp gitleaks config"
+
+[extend]
+useDefault = true
+
+[allowlist]
+description = "Placeholder keys in documentation, examples, and tests"
+paths = [
+    '''config\.example\.json''',
+    '''README\.md''',
+    '''CONTRIBUTING\.md''',
+    '''SECURITY\.md''',
+    '''CLAUDE\.md''',
+    '''examples/.*''',
+    '''tests/.*''',
+    '''\.ai/.*''',
+]
+regexes = [
+    '''YOUR_DEMANDSPHERE_API_KEY''',
+    '''your-api-key''',
+]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,25 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-toml
+      - id: check-merge-conflict
+      - id: check-added-large-files
+        args: ["--maxkb=500"]
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.8.4
+    hooks:
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format
+
+  - repo: https://github.com/Yelp/detect-secrets
+    rev: v1.5.0
+    hooks:
+      - id: detect-secrets
+        args: ["--baseline", ".secrets.baseline"]
+        exclude: "^\\.ai/|^tests/.*\\.json$"

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,0 +1,171 @@
+{
+  "version": "1.5.0",
+  "plugins_used": [
+    {
+      "name": "ArtifactoryDetector"
+    },
+    {
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "AzureStorageKeyDetector"
+    },
+    {
+      "name": "Base64HighEntropyString",
+      "limit": 4.5
+    },
+    {
+      "name": "BasicAuthDetector"
+    },
+    {
+      "name": "CloudantDetector"
+    },
+    {
+      "name": "DiscordBotTokenDetector"
+    },
+    {
+      "name": "GitHubTokenDetector"
+    },
+    {
+      "name": "GitLabTokenDetector"
+    },
+    {
+      "name": "HexHighEntropyString",
+      "limit": 3.0
+    },
+    {
+      "name": "IbmCloudIamDetector"
+    },
+    {
+      "name": "IbmCosHmacDetector"
+    },
+    {
+      "name": "IPPublicDetector"
+    },
+    {
+      "name": "JwtTokenDetector"
+    },
+    {
+      "name": "KeywordDetector",
+      "keyword_exclude": ""
+    },
+    {
+      "name": "MailchimpDetector"
+    },
+    {
+      "name": "NpmDetector"
+    },
+    {
+      "name": "OpenAIDetector"
+    },
+    {
+      "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "PypiTokenDetector"
+    },
+    {
+      "name": "SendGridDetector"
+    },
+    {
+      "name": "SlackDetector"
+    },
+    {
+      "name": "SoftlayerDetector"
+    },
+    {
+      "name": "SquareOAuthDetector"
+    },
+    {
+      "name": "StripeDetector"
+    },
+    {
+      "name": "TelegramBotTokenDetector"
+    },
+    {
+      "name": "TwilioKeyDetector"
+    }
+  ],
+  "filters_used": [
+    {
+      "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
+    },
+    {
+      "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
+      "min_level": 2
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_indirect_reference"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_likely_id_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_lock_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_not_alphanumeric_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_potential_uuid"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_prefixed_with_dollar_sign"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_sequential_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_swagger_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_templated_secret"
+    },
+    {
+      "path": "detect_secrets.filters.regex.should_exclude_file",
+      "pattern": [
+        "^\\.ai/",
+        "^\\.venv/"
+      ]
+    }
+  ],
+  "results": {
+    "README.md": [
+      {
+        "type": "Secret Keyword",
+        "filename": "README.md",
+        "hashed_secret": "11fa7c37d697f30e6aee828b4426a10f83ab2380",
+        "is_verified": false,
+        "line_number": 45
+      }
+    ],
+    "config.example.json": [
+      {
+        "type": "Secret Keyword",
+        "filename": "config.example.json",
+        "hashed_secret": "2263e69dde708fe48706b9c49d722dddcd89871b",
+        "is_verified": false,
+        "line_number": 2
+      }
+    ],
+    "examples/mcp-config-pip.json": [
+      {
+        "type": "Secret Keyword",
+        "filename": "examples/mcp-config-pip.json",
+        "hashed_secret": "d2aed6fe1b9fb7f48da133fbae832118dc50d36f",
+        "is_verified": false,
+        "line_number": 6
+      }
+    ],
+    "examples/mcp-config-uv.json": [
+      {
+        "type": "Secret Keyword",
+        "filename": "examples/mcp-config-uv.json",
+        "hashed_secret": "d2aed6fe1b9fb7f48da133fbae832118dc50d36f",
+        "is_verified": false,
+        "line_number": 11
+      }
+    ]
+  },
+  "generated_at": "2026-04-22T10:35:10Z"
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,5 @@
+# AGENTS.md
+
+This project uses [`CLAUDE.md`](./CLAUDE.md) at the repo root as the single source of truth for agent conventions. Tools following the `AGENTS.md` convention (Codex, Cursor, Aider, etc.) should read `CLAUDE.md` — the conventions apply identically regardless of which tool reads them.
+
+Kept as a plain file rather than a symlink for Windows portability.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@ uv run demandsphere-mcp                 # run server (stdio)
 ## Forbidden patterns (rejected in review)
 
 - Never log API keys, full URLs with query strings, or request bodies that contain credentials. Precedent: commit `29f2424` ("Suppress httpx request logging — leaks API keys").
-- Never use bare `except:` or `except Exception: pass` — surface the error or narrow the except clause.
+- Never use bare `except:` or `except Exception: pass` — surface the error or narrow the except clause. The one approved exception is the atexit/interpreter-shutdown cleanup pattern in `client.py::_sync_close`, where suppression is documented inline; if you add another such site, document why.
 - Never commit `config.json`, `.env`, any `*.pem`/`*.key`, or anything under `.ai/`.
 - Never edit `CHANGELOG.md` in a feature PR — the changelog is curated at release time.
 - Never inline a live API key in tests, docstrings, examples, or fixtures.
@@ -66,7 +66,7 @@ pre-commit run --all-files   # if pre-commit is installed
 
 ## Secret handling
 
-The DemandSphere API key is loaded from, in order: `DEMANDSPHERE_API_KEY` env var → `~/.config/demandsphere/config.json` → `.env` in the working directory. See `src/demandsphere_mcp/config.py`. The key travels in the DemandSphere API's URL query string — this is why server-side `httpx` request logging is suppressed. Do not re-enable it.
+The DemandSphere API key is loaded from, in order of precedence (highest wins): `DEMANDSPHERE_API_KEY` env var → `.env` in the working directory → `~/.config/demandsphere/config.json`. See `src/demandsphere_mcp/config.py`. The key travels in the DemandSphere API's URL query string — this is why server-side `httpx` request logging is suppressed. Do not re-enable it.
 
 ## Working artifacts
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,73 @@
+# CLAUDE.md
+
+Agent rules and conventions for `demandsphere-mcp`. Tools using the `AGENTS.md` convention (Codex, Cursor, Aider, etc.) should also read this file — `AGENTS.md` is a stub that points here.
+
+## Project snapshot
+
+Public MCP (Model Context Protocol) server that brokers the DemandSphere search-intelligence API (v5.0 SERP analytics + v5.1 GenAI visibility) to AI assistants. Python 3.11+, MIT-licensed, distributed via GitHub. PyPI publishing is deferred to Phase 2.
+
+## Run & test commands
+
+```bash
+uv sync --extra dev                     # install dev deps
+uv run pytest                           # run tests
+uv run ruff check src/ tests/           # lint
+uv run ruff format src/ tests/          # format
+uv run demandsphere-mcp                 # run server (stdio)
+```
+
+## Architecture map
+
+- `src/demandsphere_mcp/server.py` — MCP server entry point, tool/prompt/resource registration
+- `src/demandsphere_mcp/config.py` — settings loaded from env vars and `~/.config/demandsphere/config.json`
+- `src/demandsphere_mcp/client.py` — async HTTP client and token-bucket rate limiter
+- `src/demandsphere_mcp/tools/` — one file per domain:
+  - `sites.py` — site discovery (v5.0)
+  - `keywords_v50.py` — SERP analytics (v5.0)
+  - `genai_v51.py` — GenAI visibility (v5.1)
+  - `brands_v51.py` — brand management (v5.1)
+  - `chatgpt_compat.py` — ChatGPT Deep Research `search`/`fetch`
+  - `prompts.py` — MCP Prompts (workflow templates)
+  - `resources.py` — MCP Resources (parameter discovery)
+  - `utils.py` — error handling, validation, hint builders
+
+## Code conventions
+
+- Type hints required on all public APIs — we ship `py.typed`
+- Ruff target `py311`, line length 100
+- Async HTTP via `httpx.AsyncClient` only — never `requests`
+- All schemas via `pydantic` v2
+- New tools live in `src/demandsphere_mcp/tools/<domain>.py` and register in `server.py`
+
+## Testing rules
+
+- Every new tool needs tests in `tests/test_<name>.py`
+- No real API calls — mock `httpx` (see `tests/test_core.py` for patterns)
+- Async tests use `pytest-asyncio` configured with `asyncio_mode = "auto"` — no per-test decorator needed
+- Unit tests cover validators, response shaping, and error paths
+- Integration-style tests for multi-tool flows live in `test_consolidated.py`
+
+## Forbidden patterns (rejected in review)
+
+- Never log API keys, full URLs with query strings, or request bodies that contain credentials. Precedent: commit `29f2424` ("Suppress httpx request logging — leaks API keys").
+- Never use bare `except:` or `except Exception: pass` — surface the error or narrow the except clause.
+- Never commit `config.json`, `.env`, any `*.pem`/`*.key`, or anything under `.ai/`.
+- Never edit `CHANGELOG.md` in a feature PR — the changelog is curated at release time.
+- Never inline a live API key in tests, docstrings, examples, or fixtures.
+
+## Before committing
+
+```bash
+uv run ruff check src/ tests/
+uv run ruff format --check src/ tests/
+uv run pytest
+pre-commit run --all-files   # if pre-commit is installed
+```
+
+## Secret handling
+
+The DemandSphere API key is loaded from, in order: `DEMANDSPHERE_API_KEY` env var → `~/.config/demandsphere/config.json` → `.env` in the working directory. See `src/demandsphere_mcp/config.py`. The key travels in the DemandSphere API's URL query string — this is why server-side `httpx` request logging is suppressed. Do not re-enable it.
+
+## Working artifacts
+
+`.ai/` at the repo root is the gitignored scratch space for agent specs, plans, and notes (see `.ai/README.md`). Nothing under `.ai/` is ever committed. If an artifact becomes durable project documentation, move it to the repo proper under `docs/`.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,9 +1,3 @@
-+++
-version = "2.1"
-aliases = ["/version/2/1"]
-reportingPlaceholder = "dev@demandsphere.com"
-+++
-
 # Contributor Covenant Code of Conduct
 
 ## Our Pledge

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,89 @@
++++
+version = "2.1"
+aliases = ["/version/2/1"]
+reportingPlaceholder = "dev@demandsphere.com"
++++
+
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at dev@demandsphere.com. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,12 @@
 # Contributing to DemandSphere MCP Server
 
-Thanks for your interest in contributing.
+Thanks for your interest in contributing. This project follows a lightweight workflow: fork, branch, PR, automated checks, review.
 
-## Development Setup
+## Code of Conduct
+
+Participation in this project is governed by the [Contributor Covenant Code of Conduct](./CODE_OF_CONDUCT.md). Report unacceptable behavior to `dev@demandsphere.com`.
+
+## Development setup
 
 ```bash
 git clone https://github.com/DemandSphereDev/demandsphere-mcp.git
@@ -10,37 +14,43 @@ cd demandsphere-mcp
 uv sync --extra dev
 ```
 
-## Running Tests
+Optional but recommended — install pre-commit hooks so local commits run the same checks CI does:
+
+```bash
+uv run pre-commit install
+```
+
+## Running tests
 
 ```bash
 uv run pytest
 ```
 
-## Code Style
+## Code style
 
-This project uses [ruff](https://docs.astral.sh/ruff/) for linting:
+This project uses [ruff](https://docs.astral.sh/ruff/) for linting and formatting:
 
 ```bash
 uv run ruff check src/ tests/
 uv run ruff format src/ tests/
 ```
 
-## Pull Requests
+Project-wide conventions (type hints, async patterns, tool layout, forbidden patterns) live in [`CLAUDE.md`](./CLAUDE.md). Humans should read it too — the rules apply to all contributors, not only AI agents.
+
+## Pull requests
 
 1. Fork the repo and create a feature branch from `main`
 2. Add tests for any new functionality
-3. Ensure all tests pass and ruff is clean
+3. Ensure `ruff check`, `ruff format --check`, and `pytest` all pass locally
 4. Open a PR with a clear description of the change
+5. CI (lint + test matrix + secret scan) must be green before review
 
-## Reporting Issues
+The PR template includes a checklist — please fill it in honestly.
 
-Open an issue on [GitHub](https://github.com/DemandSphereDev/demandsphere-mcp/issues) with:
+## Reporting issues
 
-- What you expected to happen
-- What actually happened
-- Steps to reproduce
-- Your environment (Python version, OS, MCP client)
+Use the issue templates on [GitHub](https://github.com/DemandSphereDev/demandsphere-mcp/issues). They collect the environment details we need (Python version, OS, MCP client, transport).
 
-## Security Issues
+## Security issues
 
-If you discover a security vulnerability, please email security@demandsphere.com instead of opening a public issue.
+Do not open public issues for security reports. See [`SECURITY.md`](./SECURITY.md) for the private reporting flow.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,40 @@
+# Security Policy
+
+## Supported versions
+
+| Version | Supported |
+|---|---|
+| `main` branch | Yes |
+| Latest tagged release | Yes |
+| Older releases | No |
+
+## Reporting a vulnerability
+
+**Do not open a public issue or discussion for security reports.**
+
+Email `security@demandsphere.com` with:
+
+- A description of the vulnerability
+- Steps to reproduce (or a proof of concept)
+- The impact you believe it has
+- Any mitigations you have identified
+
+We will acknowledge your report within **3 business days**. For confirmed issues, the target fix window is **30 days for critical severity**; lower severities are prioritized alongside normal work.
+
+## Scope
+
+In scope:
+
+- Code in this repository (`src/`, `tests/`, `Dockerfile`, workflows)
+- Direct Python dependencies declared in `pyproject.toml`
+
+Out of scope:
+
+- The DemandSphere API itself — contact DemandSphere support via the [Help Center](https://help.demandsphere.com)
+- Third-party MCP clients (Claude Desktop, Cursor, ChatGPT, etc.) — report to the respective vendor
+- Reverse proxies or hosting platforms you deploy this server behind
+
+## Known considerations
+
+- The DemandSphere API uses query-parameter authentication. The API key may appear in URL query strings sent to DemandSphere's backend. This server suppresses `httpx` request logging (commit `29f2424`) to prevent local log leaks. If you deploy the `streamable-http` transport behind a reverse proxy, configure it to strip or redact query strings from access logs.
+- The AI model using this MCP server never sees the API key — the server holds the key and injects it into outbound requests.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -25,7 +25,7 @@ We will acknowledge your report within **3 business days**. For confirmed issues
 
 In scope:
 
-- Code in this repository (`src/`, `tests/`, `Dockerfile`, workflows)
+- Code in this repository (`src/`, `tests/`, `Dockerfile`, `.github/workflows/`)
 - Direct Python dependencies declared in `pyproject.toml`
 
 Out of scope:
@@ -36,5 +36,5 @@ Out of scope:
 
 ## Known considerations
 
-- The DemandSphere API uses query-parameter authentication. The API key may appear in URL query strings sent to DemandSphere's backend. This server suppresses `httpx` request logging (commit `29f2424`) to prevent local log leaks. If you deploy the `streamable-http` transport behind a reverse proxy, configure it to strip or redact query strings from access logs.
+- The DemandSphere API uses query-parameter authentication. The API key may appear in URL query strings sent to DemandSphere's backend. This server suppresses `httpx` request logging (see [commit 29f2424](https://github.com/DemandSphereDev/demandsphere-mcp/commit/29f2424)) to prevent local log leaks. If you deploy the `streamable-http` transport behind a reverse proxy, configure it to strip or redact query strings from access logs.
 - The AI model using this MCP server never sees the API key — the server holds the key and injects it into outbound requests.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,9 +60,7 @@ addopts = "-ra --strict-markers"
 
 [tool.ruff.lint]
 select = ["E", "F", "W", "I", "B", "UP", "SIM", "RUF"]
-# B904: raise ... from err — real code-quality smell, but retrofitting it
-# touches runtime exception semantics; tracked as a follow-up after Phase 1.
-ignore = ["B904"]
+ignore = []
 
 [tool.ruff.lint.per-file-ignores]
 # Test files: B (flake8-bugbear) and SIM (simplify) often flag patterns
@@ -80,4 +78,8 @@ ignore = ["B904"]
 # cleanup pattern documented in CLAUDE.md Forbidden patterns. SIM105
 # (use contextlib.suppress) and RUF006 (store create_task handle)
 # would alter that pattern's semantics — opt out locally.
-"src/demandsphere_mcp/client.py" = ["SIM105", "RUF006"]
+# B904: raise-without-from-inside-except — retrofitting exception chaining
+# touches runtime semantics; deferred to a follow-up pass. Scoped per-file
+# (client.py and tools/utils.py) so future src/ files are subject to the rule.
+"src/demandsphere_mcp/client.py" = ["SIM105", "RUF006", "B904"]
+"src/demandsphere_mcp/tools/utils.py" = ["B904"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,24 @@ addopts = "-ra --strict-markers"
 
 [tool.ruff.lint]
 select = ["E", "F", "W", "I", "B", "UP", "SIM", "RUF"]
-ignore = []
+# B904: raise ... from err — real code-quality smell, but retrofitting it
+# touches runtime exception semantics; tracked as a follow-up after Phase 1.
+ignore = ["B904"]
 
 [tool.ruff.lint.per-file-ignores]
-"tests/*" = ["B", "SIM"]
+# Test files: B (flake8-bugbear) and SIM (simplify) often flag patterns
+# that are deliberate in test scaffolding. E501 applies to long docstrings
+# that describe test intent and are not runtime code.
+"tests/*" = ["B", "SIM", "E501"]
+# Tool modules hold LLM-facing description strings and docstrings that
+# are intentionally long for model readability — line length is a
+# Python-ergonomics rule, not a string-content one.
+"src/demandsphere_mcp/tools/*.py" = ["E501"]
+# server.py holds the MCP server instructions block (_INSTRUCTIONS) —
+# an LLM-facing multi-line string with intentionally long lines.
+"src/demandsphere_mcp/server.py" = ["E501"]
+# client.py::_sync_close is the approved atexit/interpreter-shutdown
+# cleanup pattern documented in CLAUDE.md Forbidden patterns. SIM105
+# (use contextlib.suppress) and RUF006 (store create_task handle)
+# would alter that pattern's semantics — opt out locally.
+"src/demandsphere_mcp/client.py" = ["SIM105", "RUF006"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,3 +52,15 @@ packages = ["src/demandsphere_mcp"]
 [tool.ruff]
 target-version = "py311"
 line-length = 100
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+testpaths = ["tests"]
+addopts = "-ra --strict-markers"
+
+[tool.ruff.lint]
+select = ["E", "F", "W", "I", "B", "UP", "SIM", "RUF"]
+ignore = []
+
+[tool.ruff.lint.per-file-ignores]
+"tests/*" = ["B", "SIM"]

--- a/src/demandsphere_mcp/client.py
+++ b/src/demandsphere_mcp/client.py
@@ -48,7 +48,7 @@ _RETRYABLE_STATUS = {429, 500, 502, 503, 504}
 
 def _retry_delay(attempt: int) -> float:
     """Exponential backoff with jitter."""
-    return _RETRY_BACKOFF * (2 ** attempt) + random.uniform(0, _RETRY_JITTER)
+    return _RETRY_BACKOFF * (2**attempt) + random.uniform(0, _RETRY_JITTER)
 
 
 def validate_path_param(value: str, name: str = "parameter") -> str:
@@ -316,10 +316,7 @@ def _flatten_row(row: dict) -> dict:
         if isinstance(val, dict) and "value" in val:
             out[key] = val["value"]
         elif isinstance(val, list):
-            out[key] = [
-                item.get("value", item) if isinstance(item, dict) else item
-                for item in val
-            ]
+            out[key] = [item.get("value", item) if isinstance(item, dict) else item for item in val]
         else:
             out[key] = val
     return out

--- a/src/demandsphere_mcp/client.py
+++ b/src/demandsphere_mcp/client.py
@@ -27,8 +27,8 @@ from typing import Any
 
 import httpx
 
-from .config import settings
 from . import __version__
+from .config import settings
 
 logger = logging.getLogger("demandsphere_mcp.client")
 
@@ -152,7 +152,7 @@ class DSClient:
         # ensures the connection pool is drained on graceful shutdown.
         atexit.register(self._sync_close)
 
-    async def __aenter__(self) -> "DSClient":
+    async def __aenter__(self) -> DSClient:
         return self
 
     async def __aexit__(self, *exc: object) -> None:

--- a/src/demandsphere_mcp/config.py
+++ b/src/demandsphere_mcp/config.py
@@ -35,7 +35,7 @@ def _load_file_config() -> dict:
         mode = _CONFIG_FILE.stat().st_mode
         if mode & (stat.S_IRGRP | stat.S_IROTH):
             logger.warning(
-                "Config file %s is readable by group/others. " "Consider running: chmod 600 %s",
+                "Config file %s is readable by group/others. Consider running: chmod 600 %s",
                 _CONFIG_FILE,
                 _CONFIG_FILE,
             )

--- a/src/demandsphere_mcp/config.py
+++ b/src/demandsphere_mcp/config.py
@@ -35,8 +35,7 @@ def _load_file_config() -> dict:
         mode = _CONFIG_FILE.stat().st_mode
         if mode & (stat.S_IRGRP | stat.S_IROTH):
             logger.warning(
-                "Config file %s is readable by group/others. "
-                "Consider running: chmod 600 %s",
+                "Config file %s is readable by group/others. " "Consider running: chmod 600 %s",
                 _CONFIG_FILE,
                 _CONFIG_FILE,
             )

--- a/src/demandsphere_mcp/tools/brands_v51.py
+++ b/src/demandsphere_mcp/tools/brands_v51.py
@@ -9,7 +9,6 @@ from .utils import attach_hints, safe_tool, validate_str
 
 
 def register(mcp: FastMCP, client: DSClient) -> None:
-
     @mcp.tool()
     @safe_tool
     async def list_brands(global_key: str) -> dict:

--- a/src/demandsphere_mcp/tools/brands_v51.py
+++ b/src/demandsphere_mcp/tools/brands_v51.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from mcp.server.fastmcp import FastMCP
 
 from ..client import DSClient
-from .utils import safe_tool, validate_str, attach_hints
+from .utils import attach_hints, safe_tool, validate_str
 
 
 def register(mcp: FastMCP, client: DSClient) -> None:

--- a/src/demandsphere_mcp/tools/chatgpt_compat.py
+++ b/src/demandsphere_mcp/tools/chatgpt_compat.py
@@ -39,7 +39,6 @@ _record_cache = _LRUCache()
 
 
 def register(mcp: FastMCP, client: DSClient) -> None:
-
     @mcp.tool()
     @safe_tool
     async def search(query: str) -> dict:

--- a/src/demandsphere_mcp/tools/genai_v51.py
+++ b/src/demandsphere_mcp/tools/genai_v51.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from mcp.server.fastmcp import FastMCP
 
 from ..client import DSClient, validate_path_param
-from .utils import safe_tool, clamp_limit, validate_date, validate_date_range, attach_hints
+from .utils import attach_hints, clamp_limit, safe_tool, validate_date, validate_date_range
 
 _LLM_VIEWS = {"stats", "performance", "channels", "cross_channel", "cross_llms"}
 

--- a/src/demandsphere_mcp/tools/genai_v51.py
+++ b/src/demandsphere_mcp/tools/genai_v51.py
@@ -19,7 +19,6 @@ _LLM_ENDPOINTS = {
 
 
 def register(mcp: FastMCP, client: DSClient) -> None:
-
     # ── Mentions & Citations ──────────────────────────────────────────
 
     @mcp.tool()

--- a/src/demandsphere_mcp/tools/keywords_v50.py
+++ b/src/demandsphere_mcp/tools/keywords_v50.py
@@ -17,7 +17,6 @@ _SERP_VIEWS = {"performance", "trends", "engine_comparison", "engine_summary"}
 
 
 def register(mcp: FastMCP, client: DSClient) -> None:
-
     @mcp.tool()
     @safe_tool
     async def serp_analytics(

--- a/src/demandsphere_mcp/tools/keywords_v50.py
+++ b/src/demandsphere_mcp/tools/keywords_v50.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 from mcp.server.fastmcp import FastMCP
 
 from ..client import DSClient
-from .utils import safe_tool, clamp_limit, validate_date_range, build_hints, attach_hints
+from .utils import attach_hints, build_hints, clamp_limit, safe_tool, validate_date_range
 
 _SERP_VIEWS = {"performance", "trends", "engine_comparison", "engine_summary"}
 

--- a/src/demandsphere_mcp/tools/prompts.py
+++ b/src/demandsphere_mcp/tools/prompts.py
@@ -9,7 +9,7 @@ from mcp.server.fastmcp import FastMCP
 from ..client import DSClient
 
 
-def register(mcp: FastMCP, client: DSClient) -> None:  # noqa: ARG001
+def register(mcp: FastMCP, client: DSClient) -> None:
 
     @mcp.prompt(
         name="weekly-ranking-report",

--- a/src/demandsphere_mcp/tools/prompts.py
+++ b/src/demandsphere_mcp/tools/prompts.py
@@ -10,7 +10,6 @@ from ..client import DSClient
 
 
 def register(mcp: FastMCP, client: DSClient) -> None:
-
     @mcp.prompt(
         name="weekly-ranking-report",
         description="Analyze keyword rankings for the last 7 days. Highlights drops, gains, and new top-10 entries.",

--- a/src/demandsphere_mcp/tools/resources.py
+++ b/src/demandsphere_mcp/tools/resources.py
@@ -10,7 +10,6 @@ from ..client import DSClient
 
 
 def register(mcp: FastMCP, client: DSClient) -> None:
-
     # ── Static parameter enumerations ──────────────────────────────────
 
     @mcp.resource(

--- a/src/demandsphere_mcp/tools/sites.py
+++ b/src/demandsphere_mcp/tools/sites.py
@@ -9,7 +9,6 @@ from .utils import safe_tool
 
 
 def register(mcp: FastMCP, client: DSClient) -> None:
-
     @mcp.tool()
     @safe_tool
     async def list_sites() -> dict:

--- a/src/demandsphere_mcp/tools/utils.py
+++ b/src/demandsphere_mcp/tools/utils.py
@@ -18,8 +18,9 @@ from __future__ import annotations
 import functools
 import logging
 import re
+from collections.abc import Callable, Coroutine
 from datetime import date
-from typing import Any, Callable, Coroutine
+from typing import Any
 from urllib.parse import urlparse, urlunparse
 
 import httpx

--- a/tests/test_brands.py
+++ b/tests/test_brands.py
@@ -6,7 +6,6 @@ import pytest
 
 from demandsphere_mcp.tools.brands_v51 import register
 
-
 # ── Helpers ──────────────────────────────────────────────────────────
 
 
@@ -17,11 +16,11 @@ class FakeClient:
         self._response = response or {"status": "ok", "data": {}}
         self.calls: list[tuple[str, dict]] = []
 
-    async def get(self, path: str, **kwargs) -> dict:  # noqa: ANN003
+    async def get(self, path: str, **kwargs) -> dict:
         self.calls.append(("GET", {"path": path, **kwargs}))
         return self._response
 
-    async def post(self, path: str, **kwargs) -> dict:  # noqa: ANN003
+    async def post(self, path: str, **kwargs) -> dict:
         self.calls.append(("POST", {"path": path, **kwargs}))
         return self._response
 
@@ -39,8 +38,8 @@ class FakeMCP:
     def __init__(self) -> None:
         self.tools: dict[str, object] = {}
 
-    def tool(self):  # noqa: ANN201
-        def decorator(fn):  # noqa: ANN001, ANN202
+    def tool(self):
+        def decorator(fn):
             self.tools[fn.__name__] = fn
             return fn
 
@@ -107,7 +106,7 @@ class TestUpdateBrandDryRun:
 
     @pytest.mark.asyncio
     async def test_dry_run_shows_all_changes(self):
-        mcp, client = _setup()
+        mcp, _client = _setup()
         result = await mcp.tools["update_brand"](
             global_key="site1",
             brand_id=42,
@@ -152,7 +151,7 @@ class TestDeleteBrandsDryRun:
 
     @pytest.mark.asyncio
     async def test_dry_run_hints_include_verify(self):
-        mcp, client = _setup()
+        mcp, _client = _setup()
         result = await mcp.tools["delete_brands"](
             global_key="site1",
             brand_ids=[1],

--- a/tests/test_consolidated.py
+++ b/tests/test_consolidated.py
@@ -4,9 +4,8 @@ from __future__ import annotations
 
 import pytest
 
-from demandsphere_mcp.tools.keywords_v50 import register as register_keywords
 from demandsphere_mcp.tools.genai_v51 import register as register_genai
-
+from demandsphere_mcp.tools.keywords_v50 import register as register_keywords
 
 # ── Helpers ──────────────────────────────────────────────────────────
 
@@ -17,11 +16,11 @@ class FakeClient:
     def __init__(self) -> None:
         self.calls: list[tuple[str, dict]] = []
 
-    async def get(self, path: str, **kwargs) -> dict:  # noqa: ANN003
+    async def get(self, path: str, **kwargs) -> dict:
         self.calls.append(("GET", {"path": path, **kwargs}))
         return {"data": {"records": []}}
 
-    async def post(self, path: str, **kwargs) -> dict:  # noqa: ANN003
+    async def post(self, path: str, **kwargs) -> dict:
         self.calls.append(("POST", {"path": path, **kwargs}))
         return {"results": [], "totalResults": 0}
 
@@ -48,8 +47,8 @@ class FakeMCP:
     def __init__(self) -> None:
         self.tools: dict[str, object] = {}
 
-    def tool(self):  # noqa: ANN201
-        def decorator(fn):  # noqa: ANN001, ANN202
+    def tool(self):
+        def decorator(fn):
             self.tools[fn.__name__] = fn
             return fn
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -9,20 +9,19 @@ from demandsphere_mcp.client import (
     DSApiError,
     DSClient,
     RateLimiter,
-    validate_path_param,
     _flatten_row,
+    validate_path_param,
 )
 from demandsphere_mcp.tools.utils import (
+    _classify_api_error,
     clamp_limit,
+    redact_secrets,
+    redact_url,
+    safe_tool,
     validate_date,
     validate_date_range,
     validate_str,
-    redact_url,
-    redact_secrets,
-    safe_tool,
-    _classify_api_error,
 )
-
 
 # ── validate_date ─────────────────────────────────────────────────
 

--- a/tests/test_hints.py
+++ b/tests/test_hints.py
@@ -2,8 +2,7 @@
 
 from __future__ import annotations
 
-from demandsphere_mcp.tools.utils import build_hints, attach_hints
-
+from demandsphere_mcp.tools.utils import attach_hints, build_hints
 
 # ── build_hints tests ─────────────────────────────────────────────
 

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from demandsphere_mcp.tools.prompts import register
 
-
 # ── Helpers ──────────────────────────────────────────────────────────
 
 
@@ -16,17 +15,17 @@ class FakeMCP:
     def __init__(self) -> None:
         self.prompts: dict[str, object] = {}
 
-    def prompt(self, **kwargs):  # noqa: ANN003, ANN201
+    def prompt(self, **kwargs):
         name = kwargs.get("name")
 
-        def decorator(fn):  # noqa: ANN001, ANN202
+        def decorator(fn):
             self.prompts[name or fn.__name__] = fn
             return fn
 
         return decorator
 
-    def tool(self):  # noqa: ANN201
-        def decorator(fn):  # noqa: ANN001, ANN202
+    def tool(self):
+        def decorator(fn):
             return fn
 
         return decorator

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -8,7 +8,6 @@ import pytest
 
 from demandsphere_mcp.tools.resources import register
 
-
 # ── Helpers ──────────────────────────────────────────────────────────
 
 
@@ -18,7 +17,7 @@ class FakeClient:
     def __init__(self) -> None:
         self.calls: list[tuple[str, dict]] = []
 
-    async def post(self, path: str, **kwargs) -> dict:  # noqa: ANN003
+    async def post(self, path: str, **kwargs) -> dict:
         self.calls.append(("POST", {"path": path, **kwargs}))
         return {
             "hierarchyList": [
@@ -34,15 +33,15 @@ class FakeMCP:
     def __init__(self) -> None:
         self.resources: dict[str, object] = {}
 
-    def resource(self, uri: str, **kwargs):  # noqa: ANN003, ANN201
-        def decorator(fn):  # noqa: ANN001, ANN202
+    def resource(self, uri: str, **kwargs):
+        def decorator(fn):
             self.resources[uri] = fn
             return fn
 
         return decorator
 
-    def tool(self):  # noqa: ANN201
-        def decorator(fn):  # noqa: ANN001, ANN202
+    def tool(self):
+        def decorator(fn):
             return fn
 
         return decorator


### PR DESCRIPTION
## Summary

Phase 1 of the public-repo professionalization effort described in
`.ai/specs/2026-04-22-repo-professionalization-design.md` (gitignored
design doc). Infrastructure and documentation only — no runtime code
changes.

## What's added

- Hardened `.gitignore` + `.editorconfig`
- `CLAUDE.md` agent conventions + `AGENTS.md` stub
- `SECURITY.md` (private reporting flow, SLA, scope)
- `CODE_OF_CONDUCT.md` (Contributor Covenant 2.1, dev@demandsphere.com)
- `CONTRIBUTING.md` updates linking the new docs
- `pyproject.toml`: explicit pytest + ruff.lint config with scoped ignores
  for intentional patterns (long LLM tool strings, atexit cleanup,
  exception-chaining debt)
- `.pre-commit-config.yaml` + `.secrets.baseline` (detect-secrets)
- `.github/`: CODEOWNERS (@kakkato @rgrieselhuber), Dependabot, issue +
  PR templates (bug report, feature request, config)
- `.github/workflows/ci.yml`: lint + test matrix (ubuntu+macos x
  Python 3.11/3.12/3.13) with SHA-pinned actions
- `.github/workflows/secret-scan.yml`: gitleaks CLI (license-free),
  SHA256-verified install, allowlist in `.gitleaks.toml`

## What's deferred

See `.ai/notes/phase-2-and-3-roadmap.md` (gitignored):

- **Phase 2**: PyPI publishing (OIDC), release automation, README badges,
  GHCR Docker publishing, Windows CI, Dependabot auto-merge, signed tags,
  social preview image
- **Phase 3**: codecov/coverage gate, mypy strict, OpenSSF Scorecard,
  MkDocs docs site, SBOM, CII Best Practices badge

## Known follow-ups captured during implementation

Non-blocking; all listed in `.ai/notes/phase-1-repo-settings-checklist.md`:

- `*.lock` in `.gitignore` silently excludes `uv.lock` - decide
  whether to commit for reproducible installs
- `src/demandsphere_mcp/config.py` module docstring omits `.env` file
  from the credential-order description - needs a separate PR
- `.pre-commit-config.yaml` ruff pin (v0.8.4) lags behind CI ruff -
  bump in maintenance PR or via Dependabot
- B904 (exception chaining) ignored for `client.py` + `tools/utils.py`
  - fix in follow-up PR
- Consider `ready_for_review` in CI `pull_request` trigger types
- Consider tightening `.gitleaks.toml` `tests/.*` allowlist once
  fixture files exist

## Post-merge actions

Maintainer runs the checklist in `.ai/notes/phase-1-repo-settings-checklist.md`:
branch protection, dependency graph, secret scanning, team creation,
topic tags, etc. The checklist lives under `.ai/` (gitignored) because
it's a personal reference, not project documentation.

## Checklist

- [x] No runtime code changed (except cosmetic ruff-format reflow on
      `src/demandsphere_mcp/config.py`)
- [x] All CI checks green: `lint`, 6x `test` matrix, `gitleaks`
- [x] `pre-commit run --all-files` passes locally
- [x] No secrets, `.env`, or `.ai/` contents committed
- [x] Gitleaks sanity-probed on a throwaway branch (PR #17, closed
      without merge)
- [x] `CHANGELOG.md` not modified (per CLAUDE.md rule - curated at
      release)