### PR TITLE
refactor: make demandsphere-mcp embeddable (v0.3.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,30 @@ All notable changes to the DemandSphere MCP Server will be documented in this fi
 
 This project follows [Semantic Versioning](https://semver.org/). Subscribe to releases on GitHub to be notified of updates.
 
+## [0.3.0] - 2026-04-22
+
+### Breaking
+
+- `tools.<module>.register()` no longer takes a `client` argument. Every tool module's `register(mcp: FastMCP, client: DSClient)` is now `register(mcp: FastMCP)`. Tools resolve the active `DSClient` at call time via `get_client()` instead of closing over a pre-bound instance. Downstream code that imported and called `register(mcp, client)` directly must drop the second argument.
+
+### Added
+
+- `demandsphere_mcp.client.get_client()` — returns the active `DSClient`, preferring the request-scoped `_current_client` ContextVar over the process-wide `_default_client`. Raises `RuntimeError` with an actionable message if neither is installed.
+- `demandsphere_mcp.client.set_default_client(client)` — installs the process-wide fallback `DSClient` for stdio and single-tenant streamable-HTTP bootstrap.
+- `demandsphere_mcp.client._current_client` — `ContextVar[DSClient]` that external ASGI middleware can populate per request for hosted multi-tenant deployments.
+- `DSClient(http=..., limiter=...)` — optional dependency-injection parameters so embedding apps can share a single `httpx.AsyncClient` pool and attach per-user `RateLimiter` instances. `DSClient` tracks pool ownership via a private `_owns_http` flag and skips both the `atexit` cleanup and `aclose()` when the pool is borrowed.
+- `demandsphere_mcp.server.create_asgi_app() -> Starlette` — returns the Starlette ASGI app for mounting the MCP inside a larger ASGI stack. Intentionally does not install a default client so that a missing middleware wiring surfaces as a clear error rather than silently routing every tenant through one client.
+
+### Changed
+
+- `create_server()` is now pure — it registers tools without constructing a `DSClient` and never calls `sys.exit`. Safe to import and call from tests or embedding code.
+- `main()` now orchestrates the stdio / single-tenant bootstrap: `_check_config()` → `set_default_client(DSClient())` → `create_server()` → transport dispatch.
+- Removed the `_get_server()` lazy singleton and `_server` module global from `server.py`; `create_server()` is cheap enough to call once at bootstrap.
+
+### Compatibility
+
+- Self-hosters running `demandsphere-mcp` in stdio or single-tenant streamable-HTTP mode are unaffected. No new required environment variables, no changed CLI invocation, no changed exit codes. The existing `DEMANDSPHERE_API_KEY` / config-file / `.env` precedence is preserved.
+
 ## [0.2.0] - 2026-03-11
 
 ### Changed

--- a/src/demandsphere_mcp/__init__.py
+++ b/src/demandsphere_mcp/__init__.py
@@ -1,3 +1,3 @@
 """DemandSphere MCP Server — search intelligence tools for AI assistants."""
 
-__version__ = "0.1.0"
+__version__ = "0.3.0"

--- a/src/demandsphere_mcp/client.py
+++ b/src/demandsphere_mcp/client.py
@@ -66,13 +66,14 @@ def get_client() -> DSClient:
     try:
         return _current_client.get()
     except LookupError:
-        if _default_client is not None:
-            return _default_client
-        raise RuntimeError(
-            "No DSClient in context. In hosted mode, ensure auth middleware "
-            "sets the _current_client ContextVar. In stdio mode, call "
-            "set_default_client() during bootstrap."
-        )
+        pass
+    if _default_client is not None:
+        return _default_client
+    raise RuntimeError(
+        "No DSClient in context. In hosted mode, ensure auth middleware "
+        "sets the _current_client ContextVar. In stdio mode, call "
+        "set_default_client() during bootstrap."
+    )
 
 
 # Characters allowed in URL path segments (site keys, keyword IDs, etc.)

--- a/src/demandsphere_mcp/client.py
+++ b/src/demandsphere_mcp/client.py
@@ -23,6 +23,7 @@ import logging
 import random
 import re
 import time
+from contextvars import ContextVar
 from typing import Any
 
 import httpx
@@ -35,6 +36,44 @@ logger = logging.getLogger("demandsphere_mcp.client")
 # Suppress httpx/httpcore request logging — it logs full URLs including api_key query params.
 logging.getLogger("httpx").setLevel(logging.WARNING)
 logging.getLogger("httpcore").setLevel(logging.WARNING)
+
+# Request-scoped client override. Populated by external ASGI middleware in
+# hosted mode; unset in stdio / single-tenant mode. Tools read it via
+# ``get_client()`` rather than closing over a module-level handle.
+_current_client: ContextVar[DSClient] = ContextVar("_current_client")
+
+# Process-wide fallback used when no ContextVar is set. Stdio bootstrap and
+# single-tenant streamable-http bootstrap populate this; hosted mode leaves
+# it None so that a missing ContextVar surfaces as a clear error.
+_default_client: DSClient | None = None
+
+
+def set_default_client(client: DSClient) -> None:
+    """Install the process-wide fallback DSClient (stdio / single-tenant)."""
+    global _default_client
+    _default_client = client
+
+
+def get_client() -> DSClient:
+    """Return the active DSClient.
+
+    Priority:
+      1. ``_current_client`` ContextVar (set per request in hosted mode)
+      2. ``_default_client`` module global (set at bootstrap)
+
+    Raises ``RuntimeError`` if neither is set — avoids silent misconfiguration.
+    """
+    try:
+        return _current_client.get()
+    except LookupError:
+        if _default_client is not None:
+            return _default_client
+        raise RuntimeError(
+            "No DSClient in context. In hosted mode, ensure auth middleware "
+            "sets the _current_client ContextVar. In stdio mode, call "
+            "set_default_client() during bootstrap."
+        )
+
 
 # Characters allowed in URL path segments (site keys, keyword IDs, etc.)
 _SAFE_PATH_RE = re.compile(r"^[a-zA-Z0-9_\-\.]+$")

--- a/src/demandsphere_mcp/client.py
+++ b/src/demandsphere_mcp/client.py
@@ -170,27 +170,35 @@ class DSClient:
         self,
         api_key: str | None = None,
         base_url: str | None = None,
+        http: httpx.AsyncClient | None = None,
+        limiter: RateLimiter | None = None,
     ) -> None:
         self._api_key = api_key or settings.api_key
         self._base_url = (base_url or settings.base_url).rstrip("/")
-        self._limiter = RateLimiter(settings.max_requests_per_minute)
-        self._http = httpx.AsyncClient(
-            timeout=httpx.Timeout(
-                connect=5.0,
-                read=settings.request_timeout,
-                write=10.0,
-                pool=5.0,
-            ),
-            headers={
-                "Accept": "application/json",
-                "User-Agent": f"demandsphere-mcp/{__version__}",
-            },
-        )
+
+        self._limiter = limiter or RateLimiter(settings.max_requests_per_minute)
+
+        self._owns_http = http is None
+        if http is None:
+            http = httpx.AsyncClient(
+                timeout=httpx.Timeout(
+                    connect=5.0,
+                    read=settings.request_timeout,
+                    write=10.0,
+                    pool=5.0,
+                ),
+                headers={
+                    "Accept": "application/json",
+                    "User-Agent": f"demandsphere-mcp/{__version__}",
+                },
+            )
+        self._http = http
 
         # Best-effort cleanup if the client is never explicitly closed.
-        # In stdio mode the process exits anyway; in HTTP mode this
-        # ensures the connection pool is drained on graceful shutdown.
-        atexit.register(self._sync_close)
+        # Only register when we own the pool — otherwise the embedding
+        # app is responsible for its own httpx lifecycle.
+        if self._owns_http:
+            atexit.register(self._sync_close)
 
     async def __aenter__(self) -> DSClient:
         return self
@@ -199,8 +207,10 @@ class DSClient:
         await self.close()
 
     async def close(self) -> None:
-        atexit.unregister(self._sync_close)
-        await self._http.aclose()
+        if self._owns_http:
+            atexit.unregister(self._sync_close)
+            await self._http.aclose()
+        # Injected pool: embedding app owns the lifecycle, don't close it.
 
     def _sync_close(self) -> None:
         """Synchronous close for atexit — best-effort connection pool cleanup."""

--- a/src/demandsphere_mcp/server.py
+++ b/src/demandsphere_mcp/server.py
@@ -7,7 +7,7 @@ import sys
 
 from mcp.server.fastmcp import FastMCP
 
-from .client import DSClient
+from .client import DSClient, set_default_client
 from .config import settings
 from .tools import brands_v51, chatgpt_compat, genai_v51, keywords_v50, prompts, resources, sites
 
@@ -60,9 +60,6 @@ TOOL CATEGORIES:
 - Search: search, fetch (ChatGPT Deep Research compatibility)
 """
 
-# Lazy singleton — not created at import time (#7)
-_server: FastMCP | None = None
-
 
 def _check_config() -> None:
     if settings.transport == "stdio" and not settings.api_key:
@@ -78,28 +75,21 @@ def create_server() -> FastMCP:
     """Create and configure the MCP server with all tools registered.
 
     Safe to call from tests and external code — does not call sys.exit.
+    Callers are responsible for installing a default DSClient via
+    ``set_default_client()`` (stdio / single-tenant) or arranging per-request
+    ContextVar population (hosted mode) before tools are invoked.
     """
     mcp = FastMCP("demandsphere", instructions=_INSTRUCTIONS)
-    client = DSClient()
 
-    sites.register(mcp, client)
-    keywords_v50.register(mcp, client)
-    genai_v51.register(mcp, client)
-    brands_v51.register(mcp, client)
-    chatgpt_compat.register(mcp, client)
-    prompts.register(mcp, client)
-    resources.register(mcp, client)
+    sites.register(mcp)
+    keywords_v50.register(mcp)
+    genai_v51.register(mcp)
+    brands_v51.register(mcp)
+    chatgpt_compat.register(mcp)
+    prompts.register(mcp)
+    resources.register(mcp)
 
     return mcp
-
-
-def _get_server() -> FastMCP:
-    """Lazy singleton accessor."""
-    global _server
-    if _server is None:
-        _check_config()
-        _server = create_server()
-    return _server
 
 
 def main() -> None:
@@ -110,11 +100,21 @@ def main() -> None:
         stream=sys.stderr,  # Never stdout — would corrupt stdio transport
     )
 
-    server = _get_server()
+    _check_config()
+    set_default_client(DSClient())
+    server = create_server()
 
     if settings.transport == "streamable-http":
-        logger.info("Starting DemandSphere MCP (HTTP) on %s:%d", settings.host, settings.port)
-        server.run(transport="streamable-http", host=settings.host, port=settings.port)
+        logger.info(
+            "Starting DemandSphere MCP (HTTP) on %s:%d",
+            settings.host,
+            settings.port,
+        )
+        server.run(
+            transport="streamable-http",
+            host=settings.host,
+            port=settings.port,
+        )
     else:
         server.run(transport="stdio")
 

--- a/src/demandsphere_mcp/server.py
+++ b/src/demandsphere_mcp/server.py
@@ -6,6 +6,7 @@ import logging
 import sys
 
 from mcp.server.fastmcp import FastMCP
+from starlette.applications import Starlette
 
 from .client import DSClient, set_default_client
 from .config import settings
@@ -92,7 +93,7 @@ def create_server() -> FastMCP:
     return mcp
 
 
-def create_asgi_app():
+def create_asgi_app() -> Starlette:
     """Return the Starlette ASGI app for streamable HTTP transport.
 
     Use this when embedding the MCP inside a larger ASGI stack (e.g. the

--- a/src/demandsphere_mcp/server.py
+++ b/src/demandsphere_mcp/server.py
@@ -92,6 +92,19 @@ def create_server() -> FastMCP:
     return mcp
 
 
+def create_asgi_app():
+    """Return the Starlette ASGI app for streamable HTTP transport.
+
+    Use this when embedding the MCP inside a larger ASGI stack (e.g. the
+    hosted gateway). The consuming app is responsible for installing auth
+    middleware that populates the ``_current_client`` ContextVar per request.
+
+    Intentionally does NOT call ``set_default_client()`` — relying on a
+    default in hosted mode would mask a missing middleware wiring.
+    """
+    return create_server().streamable_http_app()
+
+
 def main() -> None:
     """CLI entry point."""
     logging.basicConfig(

--- a/src/demandsphere_mcp/tools/brands_v51.py
+++ b/src/demandsphere_mcp/tools/brands_v51.py
@@ -4,21 +4,21 @@ from __future__ import annotations
 
 from mcp.server.fastmcp import FastMCP
 
-from ..client import DSClient
+from ..client import get_client
 from .utils import attach_hints, safe_tool, validate_str
 
 
-def register(mcp: FastMCP, client: DSClient) -> None:
+def register(mcp: FastMCP) -> None:
     @mcp.tool()
     @safe_tool
     async def list_brands(global_key: str) -> dict:
         """List brands configured for a site (used for GenAI mention/citation tracking)."""
         global_key = validate_str(global_key, "global_key")
-        raw = await client.get(
+        raw = await get_client().get(
             "/api/v5_1/brands/list_brands",
             params={"global_key": global_key},
         )
-        result = client.shape_v51(raw)
+        result = get_client().shape_v51(raw)
         return attach_hints(
             result,
             [
@@ -47,7 +47,7 @@ def register(mcp: FastMCP, client: DSClient) -> None:
                 },
                 "hints": ["Set dry_run=False to execute this action."],
             }
-        raw = await client.post(
+        raw = await get_client().post(
             "/api/v5_1/brands",
             json_body={
                 "global_key": global_key,
@@ -55,7 +55,7 @@ def register(mcp: FastMCP, client: DSClient) -> None:
                 "brand_description": brand_description,
             },
         )
-        result = client.shape_v51(raw)
+        result = get_client().shape_v51(raw)
         return attach_hints(
             result,
             [
@@ -93,8 +93,8 @@ def register(mcp: FastMCP, client: DSClient) -> None:
             body["brand_name"] = brand_name
         if brand_description is not None:
             body["brand_description"] = brand_description
-        raw = await client.post("/api/v5_1/brands/update_brand", json_body=body)
-        result = client.shape_v51(raw)
+        raw = await get_client().post("/api/v5_1/brands/update_brand", json_body=body)
+        result = get_client().shape_v51(raw)
         return attach_hints(
             result,
             [
@@ -121,11 +121,11 @@ def register(mcp: FastMCP, client: DSClient) -> None:
                     "Use list_brands to verify brand IDs before deleting.",
                 ],
             }
-        raw = await client.post(
+        raw = await get_client().post(
             "/api/v5_1/brands/delete_brands",
             json_body={"global_key": global_key, "brand_ids": brand_ids},
         )
-        result = client.shape_v51(raw)
+        result = get_client().shape_v51(raw)
         return attach_hints(
             result,
             [

--- a/src/demandsphere_mcp/tools/chatgpt_compat.py
+++ b/src/demandsphere_mcp/tools/chatgpt_compat.py
@@ -7,7 +7,6 @@ from collections import OrderedDict
 
 from mcp.server.fastmcp import FastMCP
 
-from ..client import DSClient
 from .utils import safe_tool
 
 # LRU-bounded cache. Prevents memory leak in long-running HTTP deployments.
@@ -38,7 +37,7 @@ class _LRUCache:
 _record_cache = _LRUCache()
 
 
-def register(mcp: FastMCP, client: DSClient) -> None:
+def register(mcp: FastMCP) -> None:
     @mcp.tool()
     @safe_tool
     async def search(query: str) -> dict:

--- a/src/demandsphere_mcp/tools/genai_v51.py
+++ b/src/demandsphere_mcp/tools/genai_v51.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from mcp.server.fastmcp import FastMCP
 
-from ..client import DSClient, validate_path_param
+from ..client import get_client, validate_path_param
 from .utils import attach_hints, clamp_limit, safe_tool, validate_date, validate_date_range
 
 _LLM_VIEWS = {"stats", "performance", "channels", "cross_channel", "cross_llms"}
@@ -18,7 +18,7 @@ _LLM_ENDPOINTS = {
 }
 
 
-def register(mcp: FastMCP, client: DSClient) -> None:
+def register(mcp: FastMCP) -> None:
     # ── Mentions & Citations ──────────────────────────────────────────
 
     @mcp.tool()
@@ -41,8 +41,8 @@ def register(mcp: FastMCP, client: DSClient) -> None:
             params["keyword_tags[]"] = keyword_tags
         if keyword_names:
             params["keyword_names[]"] = keyword_names
-        raw = await client.get(f"/v5_1/accounts/sites/{key}/mentions", params=params)
-        result = client.shape_v51(raw)
+        raw = await get_client().get(f"/v5_1/accounts/sites/{key}/mentions", params=params)
+        result = get_client().shape_v51(raw)
         return attach_hints(
             result,
             [
@@ -63,7 +63,7 @@ def register(mcp: FastMCP, client: DSClient) -> None:
         """Citation URLs for a single keyword on an AI platform."""
         key = validate_path_param(site_global_key, "site_global_key")
         validate_date(target_date, "target_date")
-        raw = await client.post(
+        raw = await get_client().post(
             f"/v5_1/accounts/sites/{key}/queries/citations",
             params={
                 "search_engine": search_engine,
@@ -71,7 +71,7 @@ def register(mcp: FastMCP, client: DSClient) -> None:
                 "query_keyword_name": keyword_name,
             },
         )
-        result = client.shape_v51(raw)
+        result = get_client().shape_v51(raw)
         return attach_hints(
             result,
             [
@@ -91,7 +91,7 @@ def register(mcp: FastMCP, client: DSClient) -> None:
         """Citation URLs for multiple keywords in one call (max 50). Returns keyword→URLs mapping."""
         key = validate_path_param(site_global_key, "site_global_key")
         validate_date(target_date, "target_date")
-        raw = await client.post(
+        raw = await get_client().post(
             f"/v5_1/accounts/sites/{key}/queries/bulk_citations",
             params={
                 "search_engine": search_engine,
@@ -99,7 +99,7 @@ def register(mcp: FastMCP, client: DSClient) -> None:
             },
             json_body={"query_keyword_names": keyword_names[:50]},
         )
-        result = client.shape_v51(raw)
+        result = get_client().shape_v51(raw)
         hints = [
             "Use get_mentions for mention counts and context sentences alongside citation URLs."
         ]
@@ -132,8 +132,8 @@ def register(mcp: FastMCP, client: DSClient) -> None:
         }
         if keyword_tags:
             params["keyword_tags[]"] = keyword_tags
-        raw = await client.get(f"/v5_1/accounts/sites/{key}/citations", params=params)
-        result = client.shape_v51(raw)
+        raw = await get_client().get(f"/v5_1/accounts/sites/{key}/citations", params=params)
+        result = get_client().shape_v51(raw)
         extra = [
             "Use get_keyword_citations for detailed citations on a single keyword.",
             "Use get_bulk_citations to fetch citations for up to 50 keywords at once.",
@@ -187,11 +187,11 @@ def register(mcp: FastMCP, client: DSClient) -> None:
                 params["channels_list"] = channels_list
 
         endpoint = _LLM_ENDPOINTS[view]
-        raw = await client.get(
+        raw = await get_client().get(
             f"/v5_1/accounts/sites/{key}/analytics/site_visits/llms/{endpoint}",
             params=params,
         )
-        result = client.shape_v51(raw)
+        result = get_client().shape_v51(raw)
 
         # View-specific hints
         if view == "stats":
@@ -228,10 +228,10 @@ def register(mcp: FastMCP, client: DSClient) -> None:
     async def get_llm_filters(site_global_key: str) -> dict:
         """Available filter values for LLM analytics: channels, LLM names, metrics."""
         key = validate_path_param(site_global_key, "site_global_key")
-        raw = await client.get(
+        raw = await get_client().get(
             f"/v5_1/accounts/sites/{key}/analytics/site_visits/llms/filters",
         )
-        result = client.shape_v51(raw)
+        result = get_client().shape_v51(raw)
         return attach_hints(
             result,
             [
@@ -276,11 +276,11 @@ def register(mcp: FastMCP, client: DSClient) -> None:
             includes.append("adword_stats")
         if includes:
             params["includes[]"] = includes
-        raw = await client.get(
+        raw = await get_client().get(
             f"/v5_1/accounts/sites/{key}/people_also_asks",
             params=params,
         )
-        result = client.shape_v51(raw)
+        result = get_client().shape_v51(raw)
         extra: list[str] = []
         records = result.get("records", []) if isinstance(result, dict) else []
         if isinstance(records, list) and len(records) >= page_limit:

--- a/src/demandsphere_mcp/tools/keywords_v50.py
+++ b/src/demandsphere_mcp/tools/keywords_v50.py
@@ -10,13 +10,13 @@ from __future__ import annotations
 
 from mcp.server.fastmcp import FastMCP
 
-from ..client import DSClient
+from ..client import get_client
 from .utils import attach_hints, build_hints, clamp_limit, safe_tool, validate_date_range
 
 _SERP_VIEWS = {"performance", "trends", "engine_comparison", "engine_summary"}
 
 
-def register(mcp: FastMCP, client: DSClient) -> None:
+def register(mcp: FastMCP) -> None:
     @mcp.tool()
     @safe_tool
     async def serp_analytics(
@@ -50,7 +50,7 @@ def register(mcp: FastMCP, client: DSClient) -> None:
 
         if view == "performance":
             limit = clamp_limit(limit)
-            raw = await client.post(
+            raw = await get_client().post(
                 "/keywords/keywords_performance_detail/list",
                 params={
                     "global_key": global_key,
@@ -64,7 +64,7 @@ def register(mcp: FastMCP, client: DSClient) -> None:
                     "page_num": page_num,
                 },
             )
-            result = client.shape_tabular(raw)
+            result = get_client().shape_tabular(raw)
             hints = build_hints(
                 total_count=result.get("total_count"),
                 returned_count=result.get("returned_count"),
@@ -93,8 +93,8 @@ def register(mcp: FastMCP, client: DSClient) -> None:
             }
             if grouped:
                 params["grouped"] = "true"
-            raw = await client.post("/keywords/ranking_trends/list", params=params)
-            result = client.shape_tabular(raw)
+            raw = await get_client().post("/keywords/ranking_trends/list", params=params)
+            result = get_client().shape_tabular(raw)
             extra = []
             if grouped:
                 extra.append("Set grouped=False to see individual keyword trends.")
@@ -125,8 +125,8 @@ def register(mcp: FastMCP, client: DSClient) -> None:
             }
             if grouped:
                 params["grouped"] = "true"
-            raw = await client.post("/keywords/search_engines/list", params=params)
-            result = client.shape_tabular(raw)
+            raw = await get_client().post("/keywords/search_engines/list", params=params)
+            result = get_client().shape_tabular(raw)
             hints = build_hints(
                 total_count=result.get("total_count"),
                 returned_count=result.get("returned_count"),
@@ -141,7 +141,7 @@ def register(mcp: FastMCP, client: DSClient) -> None:
             return attach_hints(result, hints)
 
         # engine_summary
-        raw = await client.post(
+        raw = await get_client().post(
             "/search_engines/summary/list",
             params={
                 "site_id": site_id,
@@ -151,7 +151,7 @@ def register(mcp: FastMCP, client: DSClient) -> None:
                 "granularity": granularity,
             },
         )
-        result = client.shape_tabular(raw)
+        result = get_client().shape_tabular(raw)
         hints = build_hints(
             total_count=result.get("total_count"),
             returned_count=result.get("returned_count"),
@@ -179,7 +179,7 @@ def register(mcp: FastMCP, client: DSClient) -> None:
         """Keyword group/tag performance with ranking bucket distribution (bucket0-bucket8), volume, traffic, CTR."""
         limit = clamp_limit(limit)
         validate_date_range(from_date, to_date)
-        raw = await client.post(
+        raw = await get_client().post(
             "/keywords/keyword_groups_detail/list",
             params={
                 "site_id": site_id,
@@ -193,7 +193,7 @@ def register(mcp: FastMCP, client: DSClient) -> None:
                 "page_num": page_num,
             },
         )
-        result = client.shape_tabular(raw)
+        result = get_client().shape_tabular(raw)
         hints = build_hints(
             total_count=result.get("total_count"),
             returned_count=result.get("returned_count"),
@@ -222,7 +222,7 @@ def register(mcp: FastMCP, client: DSClient) -> None:
         """Local search rankings with per-location rank history."""
         limit = clamp_limit(limit)
         validate_date_range(from_date, to_date)
-        raw = await client.post(
+        raw = await get_client().post(
             "/keywords/local_rankings/list",
             params={
                 "site_id": site_id,
@@ -236,7 +236,7 @@ def register(mcp: FastMCP, client: DSClient) -> None:
                 "page_num": page_num,
             },
         )
-        result = client.shape_tabular(raw)
+        result = get_client().shape_tabular(raw)
         hints = build_hints(
             total_count=result.get("total_count"),
             returned_count=result.get("returned_count"),
@@ -265,7 +265,7 @@ def register(mcp: FastMCP, client: DSClient) -> None:
         """Check if ranking pages match preferred landing pages. Returns match/mismatch/none status."""
         limit = clamp_limit(limit)
         validate_date_range(from_date, to_date)
-        raw = await client.post(
+        raw = await get_client().post(
             "/keywords/landing_matches/list",
             params={
                 "site_id": site_id,
@@ -279,7 +279,7 @@ def register(mcp: FastMCP, client: DSClient) -> None:
                 "page_num": page_num,
             },
         )
-        result = client.shape_tabular(raw)
+        result = get_client().shape_tabular(raw)
         hints = build_hints(
             total_count=result.get("total_count"),
             returned_count=result.get("returned_count"),
@@ -303,7 +303,7 @@ def register(mcp: FastMCP, client: DSClient) -> None:
     ) -> dict:
         """Landing page history for a specific keyword. Shows which page ranked on each date."""
         validate_date_range(from_date, to_date)
-        raw = await client.post(
+        raw = await get_client().post(
             "/pages/landings_history/list",
             params={
                 "site_id": site_id,
@@ -313,7 +313,7 @@ def register(mcp: FastMCP, client: DSClient) -> None:
                 "to": to_date,
             },
         )
-        result = client.shape_tabular(raw)
+        result = get_client().shape_tabular(raw)
         hints = build_hints(
             total_count=result.get("total_count"),
             returned_count=result.get("returned_count"),

--- a/src/demandsphere_mcp/tools/prompts.py
+++ b/src/demandsphere_mcp/tools/prompts.py
@@ -6,10 +6,8 @@ from datetime import date, timedelta
 
 from mcp.server.fastmcp import FastMCP
 
-from ..client import DSClient
 
-
-def register(mcp: FastMCP, client: DSClient) -> None:
+def register(mcp: FastMCP) -> None:
     @mcp.prompt(
         name="weekly-ranking-report",
         description="Analyze keyword rankings for the last 7 days. Highlights drops, gains, and new top-10 entries.",

--- a/src/demandsphere_mcp/tools/resources.py
+++ b/src/demandsphere_mcp/tools/resources.py
@@ -6,10 +6,10 @@ import json
 
 from mcp.server.fastmcp import FastMCP
 
-from ..client import DSClient
+from ..client import get_client
 
 
-def register(mcp: FastMCP, client: DSClient) -> None:
+def register(mcp: FastMCP) -> None:
     # ── Static parameter enumerations ──────────────────────────────────
 
     @mcp.resource(
@@ -145,7 +145,7 @@ def register(mcp: FastMCP, client: DSClient) -> None:
         description="Available sites with IDs, global keys, names, and URLs.",
     )
     async def sites() -> str:
-        raw = await client.post("/sites/hierarchy/list")
+        raw = await get_client().post("/sites/hierarchy/list")
         site_list = raw.get("hierarchyList", raw)
         return json.dumps(
             {

--- a/src/demandsphere_mcp/tools/sites.py
+++ b/src/demandsphere_mcp/tools/sites.py
@@ -4,16 +4,16 @@ from __future__ import annotations
 
 from mcp.server.fastmcp import FastMCP
 
-from ..client import DSClient
+from ..client import get_client
 from .utils import safe_tool
 
 
-def register(mcp: FastMCP, client: DSClient) -> None:
+def register(mcp: FastMCP) -> None:
     @mcp.tool()
     @safe_tool
     async def list_sites() -> dict:
         """List all sites with org/account hierarchy. Returns site IDs needed by other tools."""
-        raw = await client.post("/sites/properties/list")
+        raw = await get_client().post("/sites/properties/list")
         data = raw.get("propertyList", raw)
         hints = [
             "Each site has a global_key (for serp_analytics view='performance', v5.1 tools) and an id/site_id (for other v5.0 tools).",
@@ -28,7 +28,7 @@ def register(mcp: FastMCP, client: DSClient) -> None:
     @safe_tool
     async def list_sites_flat() -> dict:
         """List all sites as a flat array. Returns id, name, url, keyword count."""
-        raw = await client.post("/sites/hierarchy/list")
+        raw = await get_client().post("/sites/hierarchy/list")
         data = raw.get("hierarchyList", raw)
         hints = [
             "Use the id field as site_id for v5.0 keyword tools. Use global_key (from list_sites) for serp_analytics(view='performance') and v5.1 tools.",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,26 @@
+"""Shared test fixtures."""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _reset_client_state():
+    """Reset ``_default_client`` between tests so file order is irrelevant.
+
+    ``set_default_client`` mutates a module global in
+    ``demandsphere_mcp.client``. Each test that installs a FakeClient via
+    ``set_default_client`` would otherwise leak that stub into later tests.
+
+    ContextVar state does not need manual reset — pytest runs each test
+    function in a fresh task context, so any ``_current_client.set()`` call
+    is automatically scoped to the test.
+    """
+    from demandsphere_mcp import client as _client_mod
+
+    saved_default = _client_mod._default_client
+    try:
+        yield
+    finally:
+        _client_mod._default_client = saved_default

--- a/tests/test_brands.py
+++ b/tests/test_brands.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import pytest
 
+from demandsphere_mcp.client import set_default_client
 from demandsphere_mcp.tools.brands_v51 import register
 
 # ── Helpers ──────────────────────────────────────────────────────────
@@ -49,7 +50,8 @@ class FakeMCP:
 def _setup() -> tuple[FakeMCP, FakeClient]:
     mcp = FakeMCP()
     client = FakeClient()
-    register(mcp, client)
+    set_default_client(client)  # type: ignore[arg-type]
+    register(mcp)
     return mcp, client
 
 

--- a/tests/test_client_context.py
+++ b/tests/test_client_context.py
@@ -1,0 +1,42 @@
+"""ContextVar / default-client routing for DSClient resolution."""
+
+from __future__ import annotations
+
+import pytest
+
+from demandsphere_mcp.client import (
+    DSClient,
+    _current_client,
+    get_client,
+    set_default_client,
+)
+
+
+class TestGetClientFallback:
+    def test_raises_when_no_context_and_no_default(self):
+        from demandsphere_mcp import client as _client_mod
+
+        _client_mod._default_client = None
+        with pytest.raises(RuntimeError, match="No DSClient in context"):
+            get_client()
+
+    def test_returns_default_when_no_context_set(self):
+        sentinel = DSClient(api_key="default-key")
+        set_default_client(sentinel)
+        assert get_client() is sentinel
+
+
+class TestGetClientContextOverride:
+    def test_contextvar_takes_precedence_over_default(self):
+        default = DSClient(api_key="default-key")
+        scoped = DSClient(api_key="scoped-key")
+        set_default_client(default)
+
+        token = _current_client.set(scoped)
+        try:
+            assert get_client() is scoped
+        finally:
+            _current_client.reset(token)
+
+        # After reset, the default is visible again.
+        assert get_client() is default

--- a/tests/test_client_injection.py
+++ b/tests/test_client_injection.py
@@ -1,0 +1,46 @@
+"""Injection support for DSClient: shared httpx pool + custom RateLimiter."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import httpx
+
+from demandsphere_mcp.client import DSClient, RateLimiter
+
+
+class TestSharedHttpPool:
+    async def test_injected_http_is_not_closed_by_client_close(self):
+        shared = httpx.AsyncClient()
+        shared.aclose = AsyncMock(wraps=shared.aclose)
+
+        client = DSClient(api_key="k", http=shared)
+        await client.close()
+
+        shared.aclose.assert_not_awaited()
+        await shared.aclose()  # cleanup for real
+
+    async def test_owned_http_is_closed_by_client_close(self):
+        client = DSClient(api_key="k")
+        inner = client._http
+        inner.aclose = AsyncMock(wraps=inner.aclose)
+
+        await client.close()
+
+        inner.aclose.assert_awaited_once()
+
+
+class TestRateLimiterInjection:
+    def test_custom_limiter_replaces_default(self):
+        custom = RateLimiter(max_per_minute=1000, max_burst=250)
+        client = DSClient(api_key="k", limiter=custom)
+        assert client._limiter is custom
+
+    def test_default_limiter_derived_from_settings_when_not_injected(self):
+        client = DSClient(api_key="k")
+        # Default burst is max(1, max_per_minute // 6). The exact number is
+        # settings-dependent; assert the instance is fresh and not the same
+        # object as any user-supplied sentinel.
+        custom = RateLimiter(max_per_minute=1)
+        assert client._limiter is not custom
+        assert isinstance(client._limiter, RateLimiter)

--- a/tests/test_consolidated.py
+++ b/tests/test_consolidated.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import pytest
 
+from demandsphere_mcp.client import set_default_client
 from demandsphere_mcp.tools.genai_v51 import register as register_genai
 from demandsphere_mcp.tools.keywords_v50 import register as register_keywords
 
@@ -58,14 +59,16 @@ class FakeMCP:
 def _setup_keywords() -> tuple[FakeMCP, FakeClient]:
     mcp = FakeMCP()
     client = FakeClient()
-    register_keywords(mcp, client)
+    set_default_client(client)  # type: ignore[arg-type]
+    register_keywords(mcp)
     return mcp, client
 
 
 def _setup_genai() -> tuple[FakeMCP, FakeClient]:
     mcp = FakeMCP()
     client = FakeClient()
-    register_genai(mcp, client)
+    set_default_client(client)  # type: ignore[arg-type]
+    register_genai(mcp)
     return mcp, client
 
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -513,3 +513,19 @@ class TestDSApiError:
         err = DSApiError(500, "Server error")
         assert "500" in str(err)
         assert "Server error" in str(err)
+
+
+class TestCreateAsgiApp:
+    def test_returns_asgi_app_without_touching_default_client(self):
+        from starlette.applications import Starlette
+
+        from demandsphere_mcp import client as _client_mod
+        from demandsphere_mcp.server import create_asgi_app
+
+        _client_mod._default_client = None
+        app = create_asgi_app()
+
+        assert isinstance(app, Starlette)
+        # Critical contract: embedding apps install their own middleware, so
+        # create_asgi_app() must NOT install a default client behind their back.
+        assert _client_mod._default_client is None

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -7,10 +7,6 @@ from demandsphere_mcp.tools.prompts import register
 # ── Helpers ──────────────────────────────────────────────────────────
 
 
-class FakeClient:
-    pass
-
-
 class FakeMCP:
     def __init__(self) -> None:
         self.prompts: dict[str, object] = {}
@@ -33,8 +29,7 @@ class FakeMCP:
 
 def _setup() -> FakeMCP:
     mcp = FakeMCP()
-    client = FakeClient()
-    register(mcp, client)
+    register(mcp)
     return mcp
 
 

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -6,6 +6,7 @@ import json
 
 import pytest
 
+from demandsphere_mcp.client import set_default_client
 from demandsphere_mcp.tools.resources import register
 
 # ── Helpers ──────────────────────────────────────────────────────────
@@ -50,7 +51,8 @@ class FakeMCP:
 def _setup() -> tuple[FakeMCP, FakeClient]:
     mcp = FakeMCP()
     client = FakeClient()
-    register(mcp, client)
+    set_default_client(client)  # type: ignore[arg-type]
+    register(mcp)
     return mcp, client
 
 


### PR DESCRIPTION
## Summary

Makes `demandsphere-mcp` embeddable so the future hosted gateway can wrap it with per-request auth middleware, while preserving the stdio / single-tenant self-hoster contract unchanged.

- **New client-resolution indirection**: `get_client()` / `set_default_client()` / `_current_client` ContextVar. Tools resolve their active `DSClient` at call time — the ContextVar wins (hosted mode), else the process-wide default (stdio), else `RuntimeError` with an actionable message.
- **`DSClient` gains injection points**: `http: httpx.AsyncClient | None` and `limiter: RateLimiter | None`. Ownership tracked via `_owns_http` — borrowed pools are not `aclose`d and don't register an `atexit` handler.
- **`create_asgi_app() -> Starlette`** exposes the Starlette app for mounting into a larger ASGI stack. Intentionally does not install a default client.
- **Breaking**: `tools.<mod>.register(mcp, client)` → `register(mcp)`. Any downstream that imported `register` directly must drop the client argument. `register()` is not a documented public API but the rename is still real.
- Bumps `__version__` to `0.3.0`. CHANGELOG entry included this time by request.

## Backward compatibility

Self-hosters running `demandsphere-mcp` in stdio or single-tenant HTTP mode see no user-visible change:
- `DEMANDSPHERE_API_KEY` / `.env` / `~/.config/demandsphere/config.json` precedence unchanged
- `_check_config()` still exits 1 when the key is missing in stdio mode, with the same error text
- CLI invocation identical

## Test plan

- [x] `uv run pytest -q` — 177 passed (169 baseline + 8 new: 3 ContextVar routing, 4 DSClient injection, 1 `create_asgi_app` contract)
- [x] `uv run ruff check src/ tests/ && uv run ruff format --check src/ tests/` — clean
- [x] Pre-commit hooks (detect-secrets, ruff, ruff-format, trim-whitespace, EOF, merge-conflicts, large-files) — clean across every commit
- [x] Spec-compliance + code-quality review on each of the 5 non-trivial commits; final whole-branch review: green-light
- [ ] Manual smoke test of stdio mode with a live API key before tagging v0.3.0

## Commit-by-commit walk

1. `8501372` feat(client): add ContextVar + get_client() + set_default_client() — additive, no behavior change
2. `f446252` style(client): avoid implicit exception chaining in get_client() — review follow-up
3. `e1736d1` feat(client): DSClient accepts injected http pool and rate limiter — +4 tests
4. `1dac422` refactor!: tool.register() drops client arg; use get_client() — atomic migration across 12 files
5. `5caac96` feat(server): expose create_asgi_app() for embedding — +1 contract test
6. `0542ef9` style(server): annotate create_asgi_app() return type — CLAUDE.md `py.typed` compliance
7. `93d81e6` chore(release): bump version to 0.3.0
8. `d039458` docs(changelog): add [0.3.0] entry

## Release checklist (for after merge)

- [ ] Tag `v0.3.0` on the merge commit and push the tag
- [ ] Downstream gateway can now pin: `demandsphere-mcp @ git+https://github.com/DemandSphereDev/demandsphere-mcp.git@v0.3.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)