### PR TITLE
fix(safe_tool): set isError=True on error; clarify list_sites hint

### DIFF
--- a/src/demandsphere_mcp/tools/sites.py
+++ b/src/demandsphere_mcp/tools/sites.py
@@ -16,7 +16,7 @@ def register(mcp: FastMCP) -> None:
         raw = await get_client().post("/sites/properties/list")
         data = raw.get("propertyList", raw)
         hints = [
-            "Each site has a global_key (for serp_analytics view='performance', v5.1 tools) and an id/site_id (for other v5.0 tools).",
+            "The site `id` field returned above is the identifier to pass as `site_id` (v5.0 tools like serp_analytics view='trends') OR as `site_global_key` / `global_key` (v5.1 GenAI and brand tools). There is no separate `global_key` field to look up.",
             "Use list_sites_flat for a simpler flat list with keyword counts.",
         ]
         if isinstance(data, dict):

--- a/src/demandsphere_mcp/tools/utils.py
+++ b/src/demandsphere_mcp/tools/utils.py
@@ -16,6 +16,7 @@ don't duplicate or drift:
 from __future__ import annotations
 
 import functools
+import json
 import logging
 import re
 from collections.abc import Callable, Coroutine
@@ -24,6 +25,7 @@ from typing import Any
 from urllib.parse import urlparse, urlunparse
 
 import httpx
+from mcp.types import CallToolResult, TextContent
 
 from ..client import DSApiError
 from ..config import settings
@@ -163,10 +165,24 @@ def _recovery_hint(error_type: str) -> str:
 # ── Tool error handling decorator ─────────────────────────────────────
 
 
+def _error_result(error_dict: dict) -> CallToolResult:
+    """Wrap a structured error dict in a CallToolResult with isError=True.
+
+    The structured dict (error_type, recovery_hint, etc.) is preserved
+    verbatim inside a single TextContent block so LLM tool-callers can
+    still parse it, while the MCP JSON-RPC envelope correctly flags the
+    call as failed via ``isError=True``.
+    """
+    return CallToolResult(
+        isError=True,
+        content=[TextContent(type="text", text=json.dumps(error_dict))],
+    )
+
+
 def safe_tool(
     fn: Callable[..., Coroutine[Any, Any, dict]],
-) -> Callable[..., Coroutine[Any, Any, dict]]:
-    """Decorator that catches API and network errors, returning structured error dicts.
+) -> Callable[..., Coroutine[Any, Any, dict | CallToolResult]]:
+    """Decorator that catches API and network errors, returning structured error envelopes.
 
     Each error includes an ``error_type`` string so the LLM can decide
     whether to retry, rephrase, or give up:
@@ -179,54 +195,67 @@ def safe_tool(
     - ``upstream_error`` — DS API 5xx, retry once
     - ``network_error`` — connection failed, retry once
     - ``internal_error`` — unexpected, retry once
+
+    On error the decorator returns a ``CallToolResult`` with
+    ``isError=True`` so MCP clients that inspect the JSON-RPC envelope
+    correctly identify the call as failed. The structured error dict
+    is preserved inside the content for LLM consumption.
     """
 
     @functools.wraps(fn)
-    async def wrapper(*args: Any, **kwargs: Any) -> dict:
+    async def wrapper(*args: Any, **kwargs: Any) -> dict | CallToolResult:
         try:
             return await fn(*args, **kwargs)
         except DSApiError as exc:
             detail = redact_secrets(exc.detail)
             logger.warning("DS API error in %s: %s", fn.__name__, detail)
             error_type = _classify_api_error(exc.status_code)
-            return {
-                "error": True,
-                "error_type": error_type,
-                "status_code": exc.status_code,
-                "message": detail,
-                "recovery_hint": _recovery_hint(error_type),
-                "tool": fn.__name__,
-            }
+            return _error_result(
+                {
+                    "error": True,
+                    "error_type": error_type,
+                    "status_code": exc.status_code,
+                    "message": detail,
+                    "recovery_hint": _recovery_hint(error_type),
+                    "tool": fn.__name__,
+                }
+            )
         except httpx.TimeoutException:
             logger.warning("Timeout in %s", fn.__name__)
-            return {
-                "error": True,
-                "error_type": "timeout",
-                "status_code": 408,
-                "message": "Request timed out. Try again or use a smaller date range / limit.",
-                "recovery_hint": _recovery_hint("timeout"),
-                "tool": fn.__name__,
-            }
+            return _error_result(
+                {
+                    "error": True,
+                    "error_type": "timeout",
+                    "status_code": 408,
+                    "message": "Request timed out. Try again or use a smaller date range / limit.",
+                    "recovery_hint": _recovery_hint("timeout"),
+                    "tool": fn.__name__,
+                }
+            )
         except httpx.HTTPError as exc:
             logger.warning("Network error in %s: %s", fn.__name__, type(exc).__name__)
-            return {
-                "error": True,
-                "error_type": "network_error",
-                "status_code": 0,
-                "message": f"Network error: {type(exc).__name__}",
-                "recovery_hint": _recovery_hint("network_error"),
-                "tool": fn.__name__,
-            }
+            return _error_result(
+                {
+                    "error": True,
+                    "error_type": "network_error",
+                    "status_code": 0,
+                    "message": f"Network error: {type(exc).__name__}",
+                    "recovery_hint": _recovery_hint("network_error"),
+                    "tool": fn.__name__,
+                }
+            )
         except Exception:
             logger.exception("Unexpected error in %s", fn.__name__)
-            return {
-                "error": True,
-                "error_type": "internal_error",
-                "status_code": 500,
-                "message": "Internal error. Please try again.",
-                "recovery_hint": _recovery_hint("internal_error"),
-                "tool": fn.__name__,
-            }
+            return _error_result(
+                {
+                    "error": True,
+                    "error_type": "internal_error",
+                    "status_code": 500,
+                    "message": "Internal error. Please try again.",
+                    "recovery_hint": _recovery_hint("internal_error"),
+                    "tool": fn.__name__,
+                }
+            )
 
     return wrapper
 

--- a/tests/_helpers.py
+++ b/tests/_helpers.py
@@ -1,0 +1,26 @@
+"""Shared helpers for tests."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from mcp.types import CallToolResult
+
+
+def unwrap_error(result: Any) -> dict:
+    """Unwrap a safe_tool error return into its structured dict.
+
+    ``safe_tool`` wraps error payloads in ``CallToolResult(isError=True)``
+    so the MCP envelope surfaces failure correctly, but the structured
+    dict still lives inside the content as JSON. Tests that assert on
+    the dict shape go through this helper.
+
+    Passes plain dicts through unchanged so success-path and legacy
+    assertions keep working.
+    """
+    if isinstance(result, CallToolResult):
+        assert result.isError is True, "unwrap_error called on a non-error CallToolResult"
+        assert result.content, "CallToolResult has no content"
+        return json.loads(result.content[0].text)
+    return result

--- a/tests/test_consolidated.py
+++ b/tests/test_consolidated.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import pytest
+from _helpers import unwrap_error
 
 from demandsphere_mcp.client import set_default_client
 from demandsphere_mcp.tools.genai_v51 import register as register_genai
@@ -103,55 +104,65 @@ class TestSerpAnalytics:
     @pytest.mark.asyncio
     async def test_invalid_view(self):
         mcp, _ = _setup_keywords()
-        result = await mcp.tools["serp_analytics"](
-            view="bad",
-            search_engine="google_us",
-            from_date="2025-01-01",
-            to_date="2025-01-07",
+        result = unwrap_error(
+            await mcp.tools["serp_analytics"](
+                view="bad",
+                search_engine="google_us",
+                from_date="2025-01-01",
+                to_date="2025-01-07",
+            )
         )
         assert result["error"] is True
 
     @pytest.mark.asyncio
     async def test_performance_requires_global_key(self):
         mcp, _ = _setup_keywords()
-        result = await mcp.tools["serp_analytics"](
-            view="performance",
-            search_engine="google_us",
-            from_date="2025-01-01",
-            to_date="2025-01-07",
+        result = unwrap_error(
+            await mcp.tools["serp_analytics"](
+                view="performance",
+                search_engine="google_us",
+                from_date="2025-01-01",
+                to_date="2025-01-07",
+            )
         )
         assert result["error"] is True
 
     @pytest.mark.asyncio
     async def test_trends_requires_site_id(self):
         mcp, _ = _setup_keywords()
-        result = await mcp.tools["serp_analytics"](
-            view="trends",
-            search_engine="google_us",
-            from_date="2025-01-01",
-            to_date="2025-01-07",
+        result = unwrap_error(
+            await mcp.tools["serp_analytics"](
+                view="trends",
+                search_engine="google_us",
+                from_date="2025-01-01",
+                to_date="2025-01-07",
+            )
         )
         assert result["error"] is True
 
     @pytest.mark.asyncio
     async def test_engine_comparison_requires_site_id(self):
         mcp, _ = _setup_keywords()
-        result = await mcp.tools["serp_analytics"](
-            view="engine_comparison",
-            search_engine="google_us",
-            from_date="2025-01-01",
-            to_date="2025-01-07",
+        result = unwrap_error(
+            await mcp.tools["serp_analytics"](
+                view="engine_comparison",
+                search_engine="google_us",
+                from_date="2025-01-01",
+                to_date="2025-01-07",
+            )
         )
         assert result["error"] is True
 
     @pytest.mark.asyncio
     async def test_engine_summary_requires_site_id(self):
         mcp, _ = _setup_keywords()
-        result = await mcp.tools["serp_analytics"](
-            view="engine_summary",
-            search_engine="google_us",
-            from_date="2025-01-01",
-            to_date="2025-01-07",
+        result = unwrap_error(
+            await mcp.tools["serp_analytics"](
+                view="engine_summary",
+                search_engine="google_us",
+                from_date="2025-01-01",
+                to_date="2025-01-07",
+            )
         )
         assert result["error"] is True
 
@@ -285,9 +296,11 @@ class TestLlmAnalytics:
     @pytest.mark.asyncio
     async def test_invalid_view(self):
         mcp, _ = _setup_genai()
-        result = await mcp.tools["llm_analytics"](
-            view="bad",
-            site_global_key="site1",
+        result = unwrap_error(
+            await mcp.tools["llm_analytics"](
+                view="bad",
+                site_global_key="site1",
+            )
         )
         assert result["error"] is True
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import httpx
 import pytest
+from _helpers import unwrap_error
 
 from demandsphere_mcp.client import (
     DSApiError,
@@ -253,7 +254,7 @@ class TestSafeTool:
         async def bad_tool() -> dict:
             raise DSApiError(401, "Invalid API key")
 
-        result = await bad_tool()
+        result = unwrap_error(await bad_tool())
         assert result["error"] is True
         assert result["error_type"] == "auth_error"
         assert result["status_code"] == 401
@@ -267,7 +268,7 @@ class TestSafeTool:
         async def timeout_tool() -> dict:
             raise httpx.ReadTimeout("read timeout")
 
-        result = await timeout_tool()
+        result = unwrap_error(await timeout_tool())
         assert result["error"] is True
         assert result["error_type"] == "timeout"
         assert "recovery_hint" in result
@@ -279,7 +280,7 @@ class TestSafeTool:
         async def net_tool() -> dict:
             raise httpx.ConnectError("connection refused")
 
-        result = await net_tool()
+        result = unwrap_error(await net_tool())
         assert result["error"] is True
         assert result["error_type"] == "network_error"
         assert "recovery_hint" in result
@@ -291,7 +292,7 @@ class TestSafeTool:
         async def crash_tool() -> dict:
             raise RuntimeError("unexpected")
 
-        result = await crash_tool()
+        result = unwrap_error(await crash_tool())
         assert result["error"] is True
         assert result["error_type"] == "internal_error"
         assert result["status_code"] == 500
@@ -304,7 +305,7 @@ class TestSafeTool:
         async def leaky_tool() -> dict:
             raise DSApiError(400, "Bad request at url?api_key=secret123")
 
-        result = await leaky_tool()
+        result = unwrap_error(await leaky_tool())
         assert "secret123" not in result["message"]
         assert "api_key=[REDACTED]" in result["message"]
 
@@ -314,7 +315,7 @@ class TestSafeTool:
         async def val_tool() -> dict:
             raise DSApiError(400, "Invalid date format")
 
-        result = await val_tool()
+        result = unwrap_error(await val_tool())
         assert result["error_type"] == "validation_error"
         assert "YYYY-MM-DD" in result["recovery_hint"]
 
@@ -324,7 +325,7 @@ class TestSafeTool:
         async def missing_tool() -> dict:
             raise DSApiError(404, "Site not found")
 
-        result = await missing_tool()
+        result = unwrap_error(await missing_tool())
         assert result["error_type"] == "not_found"
         assert "list_sites" in result["recovery_hint"]
 
@@ -334,7 +335,7 @@ class TestSafeTool:
         async def throttled_tool() -> dict:
             raise DSApiError(429, "Too many requests")
 
-        result = await throttled_tool()
+        result = unwrap_error(await throttled_tool())
         assert result["error_type"] == "rate_limited"
         assert "Wait" in result["recovery_hint"]
 
@@ -344,7 +345,7 @@ class TestSafeTool:
         async def upstream_tool() -> dict:
             raise DSApiError(502, "Bad gateway")
 
-        result = await upstream_tool()
+        result = unwrap_error(await upstream_tool())
         assert result["error_type"] == "upstream_error"
         assert "server error" in result["recovery_hint"]
 

--- a/tests/tools/test_safe_tool_error_envelope.py
+++ b/tests/tools/test_safe_tool_error_envelope.py
@@ -1,0 +1,34 @@
+"""Verify safe_tool surfaces isError=True on the MCP envelope for upstream errors."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from mcp.server.fastmcp import FastMCP
+from mcp.shared.memory import create_connected_server_and_client_session
+
+from demandsphere_mcp.client import DSApiError
+from demandsphere_mcp.tools.utils import safe_tool
+
+
+@pytest.mark.asyncio
+async def test_safe_tool_returns_iserror_true_on_dsapierror():
+    mcp = FastMCP("test")
+
+    @mcp.tool()
+    @safe_tool
+    async def always_fails() -> dict:
+        raise DSApiError(400, "boom")
+
+    async with create_connected_server_and_client_session(mcp._mcp_server) as client:
+        await client.initialize()
+        result = await client.call_tool("always_fails", {})
+
+    assert result.isError is True, (
+        f"Expected isError=True on envelope, got {result.isError}. " f"Content: {result.content}"
+    )
+    payload = json.loads(result.content[0].text)
+    assert payload["error"] is True
+    assert payload["error_type"] == "validation_error"
+    assert payload["status_code"] == 400

--- a/tests/tools/test_sites_hint.py
+++ b/tests/tools/test_sites_hint.py
@@ -1,0 +1,41 @@
+"""Verify list_sites hint does not misrepresent global_key vs id."""
+
+from __future__ import annotations
+
+import pytest
+
+from demandsphere_mcp.client import set_default_client
+from demandsphere_mcp.tools.sites import register as register_sites
+
+
+class _FakeClient:
+    async def post(self, path: str, **kwargs) -> dict:
+        return {"organizations": [], "accounts": []}
+
+
+class _FakeMCP:
+    def __init__(self) -> None:
+        self.tools: dict[str, object] = {}
+
+    def tool(self):
+        def decorator(fn):
+            self.tools[fn.__name__] = fn
+            return fn
+
+        return decorator
+
+
+@pytest.mark.asyncio
+async def test_list_sites_hint_clarifies_id_is_global_key():
+    mcp = _FakeMCP()
+    set_default_client(_FakeClient())  # type: ignore[arg-type]
+    register_sites(mcp)
+
+    result = await mcp.tools["list_sites"]()
+    hints = result["hints"]
+    combined = " ".join(hints).lower()
+
+    assert "global_key" in combined
+    assert "id" in combined
+    # The previous wording implied id and global_key were distinct fields.
+    assert "and an id/site_id" not in combined


### PR DESCRIPTION
## Summary

Two small fixes bundled as a patch release (`v0.3.1`).

- **`safe_tool` error envelope**: error returns now surface as `CallToolResult(isError=True)` instead of a plain dict, so MCP clients reading the JSON-RPC envelope correctly recognise upstream failures. The structured error dict (`error_type`, `status_code`, `recovery_hint`, …) survives verbatim inside the `TextContent` payload, so LLM tool-callers keep the same shape.
- **`list_sites` hint**: the previous wording implied `id` and `global_key` were distinct identifiers. In practice every v5.1 tool accepts the v5.0 `id` as `site_global_key` unchanged. New hint says so.

## Test plan

- [x] `pytest tests/tools/test_safe_tool_error_envelope.py -v` — new test; asserts `isError=True` on the envelope and that the structured dict survives in `content[0].text`.
- [x] `pytest tests/tools/test_sites_hint.py -v` — new test; asserts the old "and an id/site_id" phrasing is gone and the new clarification is present.
- [x] Full suite: `pytest` — 179 passed. A new `tests/_helpers.py::unwrap_error` helper adapts existing dict-shaped error assertions to the new `CallToolResult` return type.

Targets `v0.3.1` (patch: isError is a bug fix, hint rewrite is docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)